### PR TITLE
Implement dependent dimension expressions.

### DIFF
--- a/hypercube/__init__.py
+++ b/hypercube/__init__.py
@@ -22,6 +22,7 @@ from hypercube.base_cube import HyperCube
 from hypercube.numpy_cube import NumpyHyperCube
 from hypercube.cuda_cube import CUDAHyperCube
 
+from hypercube.version import __version__
 from hypercube.tests import test
 
 def hypercube(cube_type, **kwargs):

--- a/hypercube/base_cube.py
+++ b/hypercube/base_cube.py
@@ -562,7 +562,9 @@ class HyperCube(object):
             'Local Size', 'Extents')
         yield '-'*80
 
-        for d in sorted(self._dims.itervalues(), key=lambda x: x.name.upper()):
+        for d in sorted(self.dimensions(reify=True).itervalues(),
+            key=lambda x: x.name.upper()):
+        
             yield self.fmt_dimension_line(
                 d.name, d.description, d.global_size, d.local_size, d.extents)
 

--- a/hypercube/base_cube.py
+++ b/hypercube/base_cube.py
@@ -240,14 +240,6 @@ class HyperCube(object):
         return expand_expression_map({ d.name: d.local_size
             for d in self._dims.itervalues()})
 
-    def dim_extent_dict(self):
-        """ Returns a mapping of dimension name to extents """
-        from expressions import expand_expression_map
-
-        extent_l = expand_expression_map({ d.name: d.extents[0]
-            for d in self._dims.itervalues()})
-
-
     def dim_extents(self, *args):
         """
         t_ex, bl_ex, ch_ex = slvr.dim_extents('ntime, 'nbl', 'nchan')
@@ -564,7 +556,7 @@ class HyperCube(object):
 
         for d in sorted(self.dimensions(reify=True).itervalues(),
             key=lambda x: x.name.upper()):
-        
+
             yield self.fmt_dimension_line(
                 d.name, d.description, d.global_size, d.local_size, d.extents)
 

--- a/hypercube/dims.py
+++ b/hypercube/dims.py
@@ -50,7 +50,7 @@ class Dimension(AttrDict):
             name : str
                 Name of the dimension
             dim_data : integer or another Dimension
-                If integer a fresh dictionary will be created, otherwise
+                If integer a fresh Dimension will be created, otherwise
                 dim_data will be copied.
 
         Keyword Arguments
@@ -61,7 +61,7 @@ class Dimension(AttrDict):
         super(Dimension, self).__init__()
 
         # If dim_data is an integer, start constructing a dictionary from it
-        if isinstance(dim_data, (int, long, np.integer)):
+        if isinstance(dim_data, (int, long, np.integer, str)):
             self[DIMDATA.NAME] = name
             self[DIMDATA.GLOBAL_SIZE] = dim_data
             self[DIMDATA.LOCAL_SIZE] = dim_data
@@ -143,8 +143,19 @@ class Dimension(AttrDict):
         # Check that we've been given valid values
         self.check()
 
+    def is_expression(self):
+        return (isinstance(self[DIMDATA.GLOBAL_SIZE], str) or
+            isinstance(self[DIMDATA.LOCAL_SIZE], str) or
+            isinstance(self[DIMDATA.EXTENTS][0], str) or 
+            isinstance(self[DIMDATA.EXTENTS][1], str))
+
     def check(self):
         """ Sanity check the contents of a dimension data dictionary """
+
+        # Currently, we don't check string expressions
+        if self.is_expression():
+            return
+
         ls, gs, E, name, zeros = (self[DIMDATA.LOCAL_SIZE],
             self[DIMDATA.GLOBAL_SIZE],
             self[DIMDATA.EXTENTS],

--- a/hypercube/expressions.py
+++ b/hypercube/expressions.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 SKA South Africa
+#
+# This file is part of hypercube.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Based on http://stackoverflow.com/a/9558001
+
+import ast
+import itertools
+import operator as op
+
+# supported operators
+operators = {
+    ast.Add: op.add,
+    ast.Sub: op.sub,
+    ast.Mult: op.mul,
+    ast.Div: op.truediv,
+    ast.FloorDiv : op.floordiv,
+    ast.Pow: op.pow,
+    ast.BitXor: op.xor,
+    ast.USub: op.neg,
+    ast.UAdd: op.pos,
+    # Comparisons
+    ast.Eq: op.eq,
+    ast.NotEq: op.ne,
+    ast.Lt: op.lt,
+    ast.LtE: op.le,
+    ast.Gt: op.gt,
+    ast.GtE: op.ge
+}
+
+class HCNodeVisitor(ast.NodeVisitor):
+    def __init__(self, variables=None):
+        self.vars = {} if variables is None else variables
+
+    def visit_Module(self, node):
+        res = [self.visit(n) for n in node.body]
+        return res if len(res) > 1 else res[0]
+
+    def visit_Expr(self, node):
+        return self.visit(node.value)
+
+    def visit_Str(self, node):
+        return self.visit(node.value)
+
+    def visit_Num(self, node):
+        return node.n
+
+    def visit_Compare(self, node):
+        ops = node.ops
+        operands = [node.left] + node.comparators
+        # This produces a pairwise set of iteratorss
+        a, b  = itertools.tee(operands)
+        next(b, None)
+        operand_pairs = zip(a,b)
+
+        result = True
+
+        for operation, (lhs, rhs) in zip(ops, operand_pairs):
+            result = result and \
+                operators[type(operation)](
+                    self.visit(lhs),
+                    self.visit(rhs))
+
+        return result
+
+    def visit_BinOp(self, node):
+        return operators[type(node.op)](
+            self.visit(node.left),
+            self.visit(node.right))
+
+    def visit_UnaryOp(self, node):
+        return operators[type(node.op)](
+            self.visit(node.operand))
+
+    def visit_Name(self, node):
+        value = self.vars.get(node.id, None)
+
+        if value is None:
+            raise ValueError(
+                ("Cannot find a matching variable for "
+                 "parse tree name '{n}'").format(node.id))
+
+        # We got a string (another expression) from the dictionary. Parse.
+        # TODO: extract above variable from dict in loop to optimise edge
+        # case where variable value is just another variable. Infinite loops?
+        if isinstance(value, str):
+            return HCNodeVisitor(self.vars).visit(ast.parse(value))
+        else:
+            return value
+
+    def generic_visit(self, node):
+        raise SyntaxError('Unhandled node of type %s' % type(node))
+
+def parse_expression(expr, variables=None):
+    """
+    parse_expression('nvis', variables={
+                'ntime' : 100,
+                'na' : 16,
+                'nchan': 64,
+                'nbl': 'na*(na-1)//2',
+                'nvis': 'ntime*nbl*nchan',
+            })
+    """
+
+    return HCNodeVisitor(variables).visit(ast.parse(expr))

--- a/hypercube/expressions.py
+++ b/hypercube/expressions.py
@@ -116,7 +116,9 @@ class HCNodeVisitor(ast.NodeVisitor):
 
 def parse_expression(expr, variables=None, expand=False):
     """
-    Parses expr, using substituting variables values provided
+    Parses expr, using substituting variables values provided.
+    If expand is True, any expression values in variables will
+    be replaced with their actual results.
 
     parse_expression('nvis', variables={
                 'ntime' : 100,
@@ -132,12 +134,9 @@ def parse_expression(expr, variables=None, expand=False):
     return HCNodeVisitor(variables).visit(ast.parse(expr))
 
 def expand_expression_map(dictionary):
+    """ Expand variables in the supplied directory, in-place """
     for k, v in dictionary.iteritems():
-        if not isinstance(v, str):
-            continue
-
         dictionary[k] = parse_expression(v,
-            variables=dictionary,
-            expand=True)
+            variables=dictionary, expand=True)
 
     return dictionary

--- a/hypercube/tests/__init__.py
+++ b/hypercube/tests/__init__.py
@@ -18,17 +18,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from hypercube.base_cube import HyperCube
-from hypercube.numpy_cube import NumpyHyperCube
-from hypercube.cuda_cube import CUDAHyperCube
-
-from hypercube.tests import test
-
-def hypercube(cube_type, **kwargs):
-    if cube_type == 'hypercube':
-        return HyperCube()
-    elif cube_type == 'numpy_cube':
-        return NumpyHyperCube()
-    elif cube_type == 'cuda_cube':
-        import pycuda.autoinit
-        return CUDAHyperCube(context=pycuda.autoinit.context)
+from run_tests import test

--- a/hypercube/tests/run_tests.py
+++ b/hypercube/tests/run_tests.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 SKA South Africa
+#
+# This file is part of hypercube.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+import numpy
+import os
+import sys
+import unittest
+
+import hypercube
+
+def print_versions():
+    """
+    Print the versions of software relied upon by montblanc.
+    Inspired by numexpr testing suite.
+    """
+    print('-=' * 38)
+    print('Python version:    %s' % sys.version)
+    print('Hypercube version: %s' % hypercube.__version__)
+    print("NumPy version:     %s" % numpy.__version__)
+
+    if os.name == 'posix':
+        (sysname, nodename, release, version, machine) = os.uname()
+        print('Platform:          %s-%s' % (sys.platform, machine))
+
+    print('-=' * 38)
+
+def suite():
+    import test_cube
+
+    test_suite = unittest.TestSuite()
+    niter = 1
+
+    for n in range(niter):
+        test_suite.addTest(unittest.makeSuite(test_cube.Test))
+
+    return test_suite
+
+def test():
+    print_versions()
+    return unittest.TextTestRunner().run(suite())

--- a/hypercube/tests/test_cube.py
+++ b/hypercube/tests/test_cube.py
@@ -18,17 +18,24 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from hypercube.base_cube import HyperCube
-from hypercube.numpy_cube import NumpyHyperCube
-from hypercube.cuda_cube import CUDAHyperCube
+import logging
+import unittest
+import numpy as np
+import time
+import sys
 
-from hypercube.tests import test
+class Test(unittest.TestCase):
+    """
+    """
 
-def hypercube(cube_type, **kwargs):
-    if cube_type == 'hypercube':
-        return HyperCube()
-    elif cube_type == 'numpy_cube':
-        return NumpyHyperCube()
-    elif cube_type == 'cuda_cube':
-        import pycuda.autoinit
-        return CUDAHyperCube(context=pycuda.autoinit.context)
+    def setUp(self):
+        """ Set up each test case """
+        np.random.seed(int(time.time()) & 0xFFFFFFFF)
+
+    def tearDown(self):
+        """ Tear down each test case """
+        pass
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/hypercube/tests/test_cube.py
+++ b/hypercube/tests/test_cube.py
@@ -21,6 +21,8 @@
 import unittest
 import sys
 
+import hypercube
+
 class Test(unittest.TestCase):
     """
     """
@@ -32,6 +34,59 @@ class Test(unittest.TestCase):
     def tearDown(self):
         """ Tear down each test case """
         pass
+
+    def test_dim_queries(self):
+            # Set up our problem size
+        ntime, na, nchan = 100, 64, 128
+        nbl = na*(na-1)//2
+        nvis = ntime*nbl*nchan
+
+        # Create a cube and register some dimensions
+        cube = hypercube.hypercube('hypercube')
+        cube.register_dimension('ntime', ntime)
+        cube.register_dimension('na', na)
+        cube.register_dimension('nchan', nchan)
+        cube.register_dimension('nbl', nbl)
+        cube.register_dimension('nvis', nvis)
+
+        args = ['ntime','na','nbl','nchan','nvis']
+
+        # Test that the mutiple argument form works
+        _ntime, _na, _nbl, _nchan, _nvis = cube.dim_global_size(*args)
+
+        self.assertTrue(_ntime == ntime)
+        self.assertTrue(_nbl == nbl)
+        self.assertTrue(_na == na)
+        self.assertTrue(_nchan == nchan)
+        self.assertTrue(_nvis == nvis)
+
+        # Test that the multiple arguments packed into a string form works
+        _ntime, _na, _nbl, _nchan, _nvis = cube.dim_global_size(','.join(args))
+
+        self.assertTrue(_ntime == ntime)
+        self.assertTrue(_nbl == nbl)
+        self.assertTrue(_na == na)
+        self.assertTrue(_nchan == nchan)
+        self.assertTrue(_nvis == nvis)
+
+        local_ntime, local_na, local_nchan = 10, 7, 16
+        local_nbl = local_na*(local_na-1)//2
+        local_nvis = local_ntime*local_nbl*local_nchan
+
+        values = [local_ntime, local_na, local_nbl, local_nchan, local_nvis]
+
+        for arg, ls in zip(args, values):
+            cube.update_dimension(name=arg, local_size=ls,
+                extents=[0,ls], safety=False)
+
+        # Test that the mutiple argument form works
+        _ntime, _na, _nbl, _nchan, _nvis = cube.dim_local_size(*args)
+
+        self.assertTrue(_ntime == local_ntime)
+        self.assertTrue(_nbl == local_nbl)
+        self.assertTrue(_na == local_na)
+        self.assertTrue(_nchan == local_nchan)
+        self.assertTrue(_nvis == local_nvis)
 
     def test_parse_expression(self):
         """ Test expression parsing """

--- a/hypercube/tests/test_cube.py
+++ b/hypercube/tests/test_cube.py
@@ -18,10 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import logging
 import unittest
-import numpy as np
-import time
 import sys
 
 class Test(unittest.TestCase):
@@ -30,11 +27,27 @@ class Test(unittest.TestCase):
 
     def setUp(self):
         """ Set up each test case """
-        np.random.seed(int(time.time()) & 0xFFFFFFFF)
+        pass
 
     def tearDown(self):
         """ Tear down each test case """
         pass
+
+    def test_parse_expression(self):
+        """ Test expression parsing """
+        from hypercube.expressions import parse_expression
+
+        # Set up our problem size
+        ntime, na, nchan = 100, 64, 128
+        nbl = na*(na-1)//2
+        nvis = ntime*nbl*nchan
+
+        # Check that the parser expression produces a results
+        # that agrees with our manual calculation
+        assert nvis == parse_expression('nvis',
+            variables={ 'ntime' : ntime, 'na' : na, 'nchan': nchan,
+                'nbl': 'na*(na-1)//2',
+                'nvis': 'ntime*nbl*nchan' })
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(Test)

--- a/hypercube/tests/test_cube.py
+++ b/hypercube/tests/test_cube.py
@@ -104,6 +104,43 @@ class Test(unittest.TestCase):
                 'nbl': 'na*(na-1)//2',
                 'nvis': 'ntime*nbl*nchan' })
 
+        # Now set up the above example on the hypercube
+        cube = hypercube.hypercube('hypercube')
+        cube.register_dimension('ntime', ntime)
+        cube.register_dimension('na', na)
+        cube.register_dimension('nchan', nchan)
+        cube.register_dimension('nbl', 'na*(na-1)//2')
+        cube.register_dimension('nvis', 'ntime*nbl*nchan')
+
+        # Sanity check our global dimension sizes
+        G = cube.dim_global_size_dict()
+        self.assertTrue(G['nbl'] == nbl)
+        self.assertTrue(G['nvis'] == nvis)
+
+        # Create some local variable sizes
+        local_ntime, local_na, local_nchan = 10, 7, 16
+        local_nbl = local_na*(local_na-1)//2
+        local_nvis = local_ntime*local_nbl*local_nchan
+
+        local_dims = ['ntime', 'na', 'nchan']
+        values = [local_ntime, local_na, local_nchan]
+
+        # Update local size of selected dimensions
+        for arg, ls in zip(local_dims, values):
+            cube.update_dimension(name=arg, local_size=ls,
+                extents=[0,ls], safety=False)
+
+        # Check that local dimension query produces
+        # the corrected derived sizes
+        T = cube.dim_local_size_dict()
+        self.assertTrue(T['nbl'] == local_nbl)
+        self.assertTrue(T['nvis'] == local_nvis)
+
+        # Sanity check our global dimension sizes
+        G = cube.dim_global_size_dict()
+        self.assertTrue(G['nbl'] == nbl)
+        self.assertTrue(G['nvis'] == nvis)
+
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(Test)
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/hypercube/tests/test_cube.py
+++ b/hypercube/tests/test_cube.py
@@ -132,9 +132,9 @@ class Test(unittest.TestCase):
 
         # Check that local dimension query produces
         # the corrected derived sizes
-        T = cube.dim_local_size_dict()
-        self.assertTrue(T['nbl'] == local_nbl)
-        self.assertTrue(T['nvis'] == local_nvis)
+        L = cube.dim_local_size_dict()
+        self.assertTrue(L['nbl'] == local_nbl)
+        self.assertTrue(L['nvis'] == local_nvis)
 
         # Sanity check our global dimension sizes
         G = cube.dim_global_size_dict()


### PR DESCRIPTION
Implements dependent expressions for our global, local and extent dimension attributes.

Dimension attributes can now be defined in terms of other dimensions, as in the case of *baselines* and *visibilities* below:

```python
# Set up our problem size
ntime, na, nchan = 100, 64, 128
nbl = na*(na-1)//2
nvis = ntime*nbl*nchan

# Now set up the above example on the hypercube
cube = hypercube.hypercube('hypercube')
cube.register_dimension('ntime', ntime)
cube.register_dimension('na', na)
cube.register_dimension('nchan', nchan)
cube.register_dimension('nbl', 'na*(na-1)//2')
cube.register_dimension('nvis', 'ntime*nbl*nchan')

# Sanity check our global dimension sizes
G = cube.dim_global_size_dict()
self.assertTrue(G['nbl'] == nbl)
self.assertTrue(G['nvis'] == nvis)

# Create some local variable sizes
local_ntime, local_na, local_nchan = 10, 7, 16
local_nbl = local_na*(local_na-1)//2
local_nvis = local_ntime*local_nbl*local_nchan

local_dims = ['ntime', 'na', 'nchan']
values = [local_ntime, local_na, local_nchan]

# Update local size of selected dimensions
for arg, ls in zip(local_dims, values):
    cube.update_dimension(name=arg, local_size=ls,
        extents=[0,ls], safety=False)

# Check that local dimension query produces the correct derived sizes
L = cube.dim_local_size_dict()
self.assertTrue(L['nbl'] == local_nbl)
self.assertTrue(L['nvis'] == local_nvis)
```
