### PR TITLE
Refactor Dimension from an AttrDict into a class

### DIFF
--- a/hypercube/dims.py
+++ b/hypercube/dims.py
@@ -18,142 +18,96 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+from copy import (copy as shallow_copy,
+    deepcopy)
+
 from attrdict import AttrDict
 import numpy as np
 
 DEFAULT_DESCRIPTION = 'The FOURTH dimension!'
 
-class DimData(object):
-    NAME = 'name'
-    DESCRIPTION = 'description'
-    GLOBAL_SIZE = 'global_size'
-    LOCAL_SIZE = 'local_size'
-    EXTENTS = 'extents'
-    SAFETY = 'safety'
-    ZERO_VALID = 'zero_valid'
+def create_dimension(name, dim_data, **kwargs):
+    if isinstance(dim_data, Dimension):
+        dim = deepcopy(dim_data)
+        dim.update(**kwargs)
+    else:
+        dim = Dimension(name, dim_data, **kwargs)
 
-    ALL = frozenset([NAME, DESCRIPTION, GLOBAL_SIZE, LOCAL_SIZE,
-        EXTENTS, SAFETY, ZERO_VALID])
+    return dim
 
-def create_dim_data(name, dim_data, **kwargs):
-    return Dimension(name, dim_data, **kwargs)
+class Dimension(object):
+    __slots__ = ['_name', '_global_size', '_local_size',
+        '_lower_extent', '_upper_extent',
+        '_description', '_zero_valid']
 
-class Dimension(AttrDict):
-    def __init__(self, name, dim_data, **kwargs):
+    def __init__(self, name, global_size, local_size=None,
+            lower_extent=None, upper_extent=None,
+            description=None,
+            zero_valid=True):
         """
-        Create a dimension data dictionary from dim_data
-        and keyword arguments. Keyword arguments will be
-        used to update the dictionary.
-
-        Arguments
-        ---------
-            name : str
-                Name of the dimension
-            dim_data : integer or another Dimension
-                If integer a fresh Dimension will be created, otherwise
-                dim_data will be copied.
-
-        Keyword Arguments
-        -----------------
-            Any keyword arguments applicable to the Dimension
-            object will be applied at the end of the construction process.
+        Create a dimension data dictionary from supplied argument
         """
         super(Dimension, self).__init__()
 
-        # If dim_data is an integer or string,
-        # start constructing a dictionary from it
-        if isinstance(dim_data, (int, long, np.integer, str)):
-            self[DimData.NAME] = name
-            self[DimData.GLOBAL_SIZE] = dim_data
-            self[DimData.LOCAL_SIZE] = dim_data
-            
-            if isinstance(dim_data, str):
-                self[DimData.EXTENTS] = [dim_data, dim_data]
-            else:
-                self[DimData.EXTENTS] = [0, dim_data]
+        self._name = name
+        self._global_size = global_size
+        self._local_size = local_size or global_size
+        self._lower_extent = lower_extent or (global_size
+                if isinstance(global_size, str) else 0)
+        self._upper_extent = upper_extent or global_size
+        self._description = description or DEFAULT_DESCRIPTION
+        self._zero_valid = zero_valid
 
-            self[DimData.DESCRIPTION] = DEFAULT_DESCRIPTION
-            self[DimData.SAFETY] = True
-            self[DimData.ZERO_VALID] = False
-        # Otherwise directly copy the entries
-        elif isinstance(dim_data, Dimension):
-            for k, v in dim_data.iteritems():
-                self[k] = v
-            self[DimData.NAME] = name
-        else:
-            raise TypeError(("dim_data must be an integer or a Dimension. "
-                "Received a {t} instead.").format(t=type(dim_data)))
+    @property
+    def name(self):
+        return self._name
+    
+    @property
+    def global_size(self):
+        return self._global_size
 
-        # Intersect the keyword arguments with dictionary values
-        kwargs = {k: kwargs[k] for k in kwargs.iterkeys() if k in DimData.ALL}
+    @property
+    def local_size(self):
+        return self._local_size
+    
+    @property
+    def lower_extent(self):
+        return self._lower_extent
+    
+    @property
+    def upper_extent(self):
+        return self._upper_extent
+    
+    @property
+    def extent_size(self):
+        return self.upper_extent - self.lower_extent
+    
+    @property
+    def description(self):
+        return self._description
 
-        # Now update the dimension data from any keyword arguments
-        self.update(kwargs)
+    @property
+    def zero_valid(self):
+        return self._zero_valid
 
-    def copy(self):
-        """ Defer to the constructor for copy operations """
-        return Dimension(self[DimData.NAME], self)
+    def update(self, local_size=None,
+        lower_extent=None, upper_extent=None,
+        description=None, zero_valid=None):
 
-    def update(self, other=None, **kwargs):
-        """
-        Sanitised dimension data update
-        """
-
-        from collections import Mapping, Sequence
-
-        # Just pack everything from other into kwargs
-        # for the updates below
-        # See http://stackoverflow.com/a/30242574
-        if other is not None:
-            for k, v in other.iteritems() if isinstance(other, Mapping) else other:
-                kwargs[k] = v
-
-        if DimData.NAME in kwargs:
-            self[DimData.NAME] = kwargs[DimData.NAME]
-
-        name = self[DimData.NAME]
-
-        if DimData.DESCRIPTION in kwargs:
-            self[DimData.DESCRIPTION] = kwargs[DimData.DESCRIPTION]
-
-        # Update options if present
-        if DimData.SAFETY in kwargs:
-            self[DimData.SAFETY] = kwargs[DimData.SAFETY]
-
-        if DimData.ZERO_VALID in kwargs:
-            self[DimData.ZERO_VALID] = kwargs[DimData.ZERO_VALID]
-
-        if DimData.LOCAL_SIZE in kwargs:
-            if self[DimData.SAFETY] is True:
-                raise ValueError(("Modifying local size of dimension '{d}' "
-                    "is not allowed by default. If you are sure you want "
-                    "to do this add a '{s}' : 'False' entry to the "
-                    "update dictionary.").format(d=name, s=DimData.SAFETY))
-
-            if self[DimData.ZERO_VALID] is False and kwargs[DimData.LOCAL_SIZE] == 0:
-                raise ValueError(("Modifying local size of dimension '{d}' "
-                    "to zero is not valid. If you are sure you want "
-                    "to do this add a '{s}' : 'True' entry to the "
-                    "update dictionary.").format(d=name, s=DimData.ZERO_VALID))
-
-            self[DimData.LOCAL_SIZE] = kwargs[DimData.LOCAL_SIZE]
-
-        if DimData.EXTENTS in kwargs:
-            exts = kwargs[DimData.EXTENTS]
-            if (not isinstance(exts, Sequence) or len(exts) != 2):
-                raise TypeError("'{e}' entry must be a "
-                    "sequence of length 2.".format(e=DimData.EXTENTS))
-
-            self[DimData.EXTENTS] = [v for v in exts[0:2]]
+        self._local_size = local_size or self._local_size
+        self._lower_extent = lower_extent or self._lower_extent
+        self._upper_extent = upper_extent or self._upper_extent
+        self._description = description or self._description
+        self._zero_valid = zero_valid or self._zero_valid
 
         # Check that we've been given valid values
         self.validate()
 
     def is_expression(self):
-        return (isinstance(self[DimData.GLOBAL_SIZE], str) or
-            isinstance(self[DimData.LOCAL_SIZE], str) or
-            isinstance(self[DimData.EXTENTS][0], str) or 
-            isinstance(self[DimData.EXTENTS][1], str))
+        return (isinstance(self._global_size, str) or
+            isinstance(self._local_size, str) or
+            isinstance(self._lower_extent, str) or 
+            isinstance(self._upper_extent, str))
 
     def validate(self):
         """ Validate the contents of a dimension data dictionary """
@@ -162,21 +116,16 @@ class Dimension(AttrDict):
         if self.is_expression():
             return
 
-        ls, gs, E, name, zeros = (self[DimData.LOCAL_SIZE],
-            self[DimData.GLOBAL_SIZE],
-            self[DimData.EXTENTS],
-            self[DimData.NAME],
-            self[DimData.ZERO_VALID])
-
         # Sanity validate dimensions
-        if ls > gs:
+        if self._local_size > self._global_size:
             raise ValueError("Dimension '{n}' "
                 "local size {l} is greater than "
-                "it's global size {g}".format(n=name, l=ls, g=gs))
+                "it's global size {g}".format(n=self._name,
+                    l=self._local_size, g=self._global_size))
 
-        if E[1] - E[0] > ls: 
+        if self._upper_extent - self._lower_extent > self._local_size:
             raise ValueError("Dimension '{n}' "
-                "extent range [{e0}, {e1}] ({r}) "
+                "extent range [{el}, {eu}] ({r}) "
                 "is greater than it's local size {l}. "
                 "If this dimension is defined as "
                 "an expression containing multiple "
@@ -185,14 +134,26 @@ class Dimension(AttrDict):
                 "Consider forcing the extents "
                 "to [0,1] as meaningful extents "
                 "are unlikely in these cases.".format(
-                    n=name, l=ls, e0=E[0], e1=E[1], r=(E[1] - E[0])))
+                    n=name, l=ls,
+                    el=self.lower_extent, eu=self.upper_extent,
+                    r=self.upper_extent - self.lower_extent))
 
-        if zeros:
-            assert 0 <= E[0] <= E[1] <= gs, (
-                "Dimension '{d}', global size {gs}, extents [{e0}, {e1}]"
-                    .format(d=name, gs=gs, e0=E[0], e1=E[1]))
+        if self.zero_valid:
+            assert (0 <= self.lower_extent <= self.upper_extent
+                <= self.global_size), (
+                "Dimension '{d}', global size {gs}, extents [{el}, {eu}]"
+                    .format(d=self.name, gs=self.global_size,
+                        el=self.lower_extent, eu=self.upper_extent))
         else:
-            assert 0 <= E[0] < E[1] <= gs, (
-                "Dimension '{d}', global size {gs}, extents [{e0}, {e1}]"
-                    .format(d=name, gs=gs, e0=E[0], e1=E[1]))    
+            assert (0 < self.lower_extent <= self.upper_extent
+                <= self.global_size), (
+                "Dimension '{d}', global size {gs}, extents [{el}, {eu}]"
+                    .format(d=self.name, gs=self.global_size,
+                        el=self.lower_extent, eu=self.upper_extent))
+
+    def __str__(self):
+        return ("['{n}': global: {gs} local: {ls} "
+            "lower: {el} upper: {eu}]").format(
+                n=self.name, gs=self.global_size, ls=self.local_size,
+                el=self.lower_extent, eu=self.upper_extent)
 

--- a/hypercube/examples/gridding.py
+++ b/hypercube/examples/gridding.py
@@ -56,19 +56,16 @@ print('REDUCING LOCAL PROBLEM SIZE\n',
 print('\n'*3)
 
 # Reduce local grid width to 1000 and globally handle 1000 - 1256
-cube.update_dimension(name='grid_width',
-    local_size=256, extents=[1000, 1256],
-    safety=False) # Turn off the safety for local size updates
+cube.update_dimension(name='grid_width',local_size=256,
+    lower_extent=1000, upper_extent=1256)
 
 # Reduce local grid height to 1000 and globally handle range 1000 - 1256
-cube.update_dimension(name='grid_height',
-    local_size=256, extents=[1000, 1256],
-    safety=False) # Turn off the safety for local size updates
+cube.update_dimension(name='grid_height', local_size=256,
+    lower_extent=1000, upper_extent=1256)
 
 # Reduce local number of channels to 128 and globally handle range 600-700
-cube.update_dimension(name='nchan',
-    local_size=128, extents=[600, 700],
-    safety=False) # Turn off the safety for local size updates
+cube.update_dimension(name='nchan', local_size=128,
+    lower_extent=600, upper_extent=700)
 
 print (cube)
 
@@ -77,8 +74,8 @@ print (cube)
 np_cube = hc.HyperCube()
 
 # Register dimension and array information from the original hypercube
-np_cube.register_dimensions([d for d in cube.dimensions().itervalues()])
-np_cube.register_arrays([a for a in cube.arrays().itervalues()])
+np_cube.register_dimensions(cube.dimensions().itervalues())
+np_cube.register_arrays(cube.arrays().itervalues())
 hc.create_local_numpy_arrays_on_cube(np_cube)
 
 # Get some dimension information to check our numpy shape size
@@ -99,13 +96,12 @@ try:
     cuda_cube = hc.HyperCube()
 
     # Register dimension and array information from the original hypercube
-    cuda_cube.register_dimensions([d for d in cube.dimensions().itervalues()])
-    cuda_cube.register_arrays([a for a in cube.arrays().itervalues()])
+    cuda_cube.register_dimensions(cube.dimensions().itervalues())
+    cuda_cube.register_arrays(cube.arrays().itervalues())
 
-    # Reduce local number of channels to 128 and globally handle range 600-700
+    # Reduce local number of facets to 1 and handle [0,1]
     cuda_cube.update_dimension(name='nfacet',
-        local_size=1, extents=[0, 1],
-        safety=False) # Turn off the safety for local size updates
+        local_size=1, lower_extent=0, upper_extent=1)
 
     hc.create_local_pycuda_arrays_on_cube(cuda_cube)
 

--- a/hypercube/tests/test_cube.py
+++ b/hypercube/tests/test_cube.py
@@ -60,14 +60,16 @@ class Test(unittest.TestCase):
         dims = cube.dimensions()
         self.assertTrue(dims['nvis'].global_size == nvis_expr)
         self.assertTrue(dims['nvis'].local_size == nvis_expr)
-        self.assertTrue(dims['nvis'].extents == (nvis_expr, nvis_expr))
+        self.assertTrue(dims['nvis'].lower_extent == nvis_expr)
+        self.assertTrue(dims['nvis'].upper_extent == nvis_expr)
 
         # Test that we now have concrete dimensions when
         # reification is requested
         dims = cube.dimensions(reify=True)
         self.assertTrue(dims['nvis'].global_size == nvis)
         self.assertTrue(dims['nvis'].local_size == nvis)
-        self.assertTrue(dims['nvis'].extents == (0, nvis))
+        self.assertTrue(dims['nvis'].lower_extent == 0)
+        self.assertTrue(dims['nvis'].upper_extent == nvis)
 
         # Reduce the local size of the ntime, na and nchan dimensions
         local_ntime = ntime//2
@@ -76,39 +78,41 @@ class Test(unittest.TestCase):
         local_nvis = local_ntime*local_nchan*local_na*(local_na-1)//2
 
         cube.update_dimension(name='ntime', local_size=local_ntime,
-            extents=[0,local_ntime], safety=False)
+            lower_extent=0, upper_extent=local_ntime)
         cube.update_dimension(name='na', local_size=local_na,
-            extents=[0,local_na], safety=False)
+            lower_extent=0, upper_extent=local_na)
         cube.update_dimension(name='nchan', local_size=local_nchan,
-            extents=[0,local_nchan], safety=False)
+            lower_extent=0, upper_extent=local_nchan)
 
         # Test that we now have concrete dimensions when
         # reification is requested
         dims = cube.dimensions(reify=True)
         self.assertTrue(dims['nvis'].global_size == nvis)
         self.assertTrue(dims['nvis'].local_size == local_nvis)
-        self.assertTrue(dims['nvis'].extents[0] == 0)
-        self.assertTrue(dims['nvis'].extents == (0, local_nvis))
+        self.assertTrue(dims['nvis'].lower_extent == 0)
+        self.assertTrue(dims['nvis'].upper_extent == local_nvis)
 
         # Test individual dimension retrieval
         dim = cube.dimension('nvis')
         self.assertTrue(dim.global_size == nvis_expr)
         self.assertTrue(dim.local_size == nvis_expr)
-        self.assertTrue(dim.extents == (nvis_expr, nvis_expr))
+        self.assertTrue(dim.lower_extent == nvis_expr)
+        self.assertTrue(dim.upper_extent == nvis_expr)
 
         # Test individual dimension reification
         dim = cube.dimension('nvis', reify=True)
         self.assertTrue(dim.global_size == nvis)
         self.assertTrue(dim.local_size == local_nvis)
-        self.assertTrue(dim.extents == (0, local_nvis))
+        self.assertTrue(dim.lower_extent == 0)
+        self.assertTrue(dim.upper_extent == local_nvis)
 
         # Test that we still have an abstract dimensions when
         # no reification is requested
         dims = cube.dimensions()
         self.assertTrue(dims['nvis'].global_size == nvis_expr)
         self.assertTrue(dims['nvis'].local_size == nvis_expr)
-        self.assertTrue(dims['nvis'].extents == (nvis_expr, nvis_expr))
-
+        self.assertTrue(dims['nvis'].lower_extent == nvis_expr)
+        self.assertTrue(dims['nvis'].upper_extent == nvis_expr)
 
     def test_array_registration_and_reification(self):
         """ Test array registration and reification """
@@ -142,7 +146,7 @@ class Test(unittest.TestCase):
         # Update the local size and extents of the time dimension
         local_ntime = ntime//2
         cube.update_dimension(name='ntime', local_size=local_ntime,
-            extents=[0,local_ntime], safety=False)
+            lower_extent=0, upper_extent=local_ntime)
 
         # Test that the concrete shape reflects the new local_size
         # after reifying the arrays
@@ -240,6 +244,16 @@ class Test(unittest.TestCase):
         self.assertTrue(_nchan == nchan)
         self.assertTrue(_nvis == nvis)
 
+        # Test that the mutiple argument form works
+        ((tl, tu), (al, au), (bl, bu),
+            (cl, cu), (vl, vu)) = cube.dim_extents(*args)
+
+        self.assertTrue(tl == 0 and tu == ntime)
+        self.assertTrue(bl == 0 and bu == nbl)
+        self.assertTrue(al == 0 and au == na)
+        self.assertTrue(cl == 0 and cu == nchan)
+        self.assertTrue(vl == 0 and vu == nvis)
+
         # Test that the multiple arguments packed into a string form works
         _ntime, _na, _nbl, _nchan, _nvis = cube.dim_global_size(','.join(args))
 
@@ -257,7 +271,7 @@ class Test(unittest.TestCase):
 
         for arg, ls in zip(args, values):
             cube.update_dimension(name=arg, local_size=ls,
-                extents=[0,ls], safety=False)
+                lower_extent=0, upper_extent=ls)
 
         # Test that the mutiple argument form works
         _ntime, _na, _nbl, _nchan, _nvis = cube.dim_local_size(*args)
@@ -308,7 +322,7 @@ class Test(unittest.TestCase):
         # Update local size of selected dimensions
         for arg, ls in zip(local_dims, values):
             cube.update_dimension(name=arg, local_size=ls,
-                extents=[0,ls], safety=False)
+                lower_extent=0, upper_extent=ls)
 
         # Check that local dimension query produces
         # the corrected derived sizes


### PR DESCRIPTION
Make it a class with __slots__ for each attribute guarded by properties.
Handling arbitrary **kwargs was becoming silly and the object is simpler as a result.

Also:

- Split two element extents list into lower_extents and upper_extents.
  This makes dim_lower_extent and dim_upper_extent far easier to code
  compared to the dim_extents which would have required confusing logic.
- Remove the safety flag on local_size when performing updates.