### PR TITLE
Add methods for iterating over portions of the hypercube space

### DIFF
--- a/hypercube/dims.py
+++ b/hypercube/dims.py
@@ -105,10 +105,10 @@ class Dimension(object):
         description=None, zero_valid=None,
         ignore_extents=None):
 
-        self._global_size = global_size or self._global_size
-        self._local_size = local_size or self._local_size
-        self._lower_extent = lower_extent or self._lower_extent
-        self._upper_extent = upper_extent or self._upper_extent
+        self._global_size = self._global_size if global_size is None else global_size
+        self._local_size = self._local_size if local_size is None else local_size
+        self._lower_extent = self._lower_extent if lower_extent is None else lower_extent
+        self._upper_extent = self._upper_extent if upper_extent is None else upper_extent
         self._description = description or self._description
         self._zero_valid = zero_valid or self._zero_valid
         self._ignore_extents = ignore_extents or self._ignore_extents


### PR DESCRIPTION
- `cube.endpoint_iter(('ntime', 10), ('nchan',4))` produces `((time_start, time_end), (chan_start, chan_end))` endpoints for time and channel every 10 timesteps and 4 channels respectively.
- `cube.slice_iter(('ntime', 10), ('nchan',4))` produces `(time, chan)` slices for time and channel every 10 timesteps and 4 channels respectively.
- `cube.cube_iter(('ntime', 10), ('nchan',4))` produces individual hypercubes with lower_extents, upper_extents  modified for time and channel on each iteration. The `arrays` keywords can be set to `True` to create reified array descriptors (not actual arrays) on each cube.
- `cube.slice_index('ntime', 'na')` returns a tuple of slices suitable for indexing a numpy array for example.