### PR TITLE
Prepare 0.3.6 release

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8","3.9","3.10"]
+        python-version: ["3.9","3.10","3.11","3.12"]
 
     steps:
     - uses: actions/checkout@v3
@@ -39,7 +39,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pynose # replacement for nose
+        python -m pip install nose2 # replacement for nose
         if [ -f requirements.txt ]; then 
           pip install -r requirements.txt; 
         else
@@ -47,4 +47,4 @@ jobs:
         fi
     - name: Test
       run: |
-        pynose .
+        nose2 hypercube

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,6 +6,7 @@ name: Python package
 on:
   push:
   pull_request:
+    branches: ["**"]
   schedule:
     - cron: '30 2 * * 1' # Every Monday @ 2h30am UTC
 

--- a/hypercube/util/__init__.py
+++ b/hypercube/util/__init__.py
@@ -25,7 +25,7 @@ from hypercube.dims import Dimension
 
 def array_bytes(array):
     """ Estimates the memory of the supplied array in bytes """
-    return np.product(array.shape)*np.dtype(array.dtype).itemsize
+    return np.prod(array.shape)*np.dtype(array.dtype).itemsize
 
 def fmt_bytes(nbytes):
     """ Returns a human readable string, given the number of bytes """

--- a/hypercube/version.py
+++ b/hypercube/version.py
@@ -1,3 +1,2 @@
-import pkg_resources
-
-__version__ = pkg_resources.get_distribution("hypercube").version
+from importlib.metadata import version
+__version__ = version("hypercube")

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def readme():
         return f.read()
 
 setup(name='hypercube',
-    version='0.3.5',
+    version='0.3.6',
     description='Actually an n-orthotope.',
     long_description=readme(),
     url='http://github.com/ska-sa/hypercube',


### PR DESCRIPTION
- fix numpy deprecation of np.product (replaced with np.prod)
- remove use of pkg_resources in favor of importlib
- remove 3.8 from test matrix
- use nose2 instead of pynose... seems to be broken now for python 3.12